### PR TITLE
Add GIF generation

### DIFF
--- a/iopaint/api.py
+++ b/iopaint/api.py
@@ -202,6 +202,22 @@ class Api:
         with open(output_path, "wb") as fw:
             fw.write(origin_image_bytes)
 
+        if self.config.enable_gif:
+            try:
+                from iopaint.plugins.make_gif import make_gif
+
+                if self.config.input:
+                    if self.config.input.is_file():
+                        orig_path = self.config.input
+                    else:
+                        orig_path = self.config.input / safe_filename
+
+                    if orig_path.exists():
+                        gif_path = output_path.with_suffix(".gif")
+                        make_gif(orig_path, output_path, gif_path)
+            except Exception as e:  # pragma: no cover - best effort
+                logger.error(f"Make GIF failed: {e}")
+
     def api_current_model(self) -> ModelInfo:
         return self.model_manager.current_model
 

--- a/iopaint/cli.py
+++ b/iopaint/cli.py
@@ -141,6 +141,7 @@ def start(
     realesrgan_model: RealESRGANModel = Option(RealESRGANModel.realesr_general_x4v3),
     enable_gfpgan: bool = Option(False),
     gfpgan_device: Device = Option(Device.cpu),
+    enable_gif: bool = Option(False, help=GIF_HELP),
     enable_restoreformer: bool = Option(False),
     restoreformer_device: Device = Option(Device.cpu),
 ):
@@ -222,6 +223,7 @@ def start(
         realesrgan_model=realesrgan_model,
         enable_gfpgan=enable_gfpgan,
         gfpgan_device=gfpgan_device,
+        enable_gif=enable_gif,
         enable_restoreformer=enable_restoreformer,
         restoreformer_device=restoreformer_device,
     )

--- a/iopaint/plugins/make_gif.py
+++ b/iopaint/plugins/make_gif.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from typing import Iterable
+
+from PIL import Image
+import imageio
+
+
+def make_gif(original: Path, cleaned: Path, gif_path: Path, duration: float = 0.5) -> None:
+    """Create a GIF comparing original and cleaned images.
+
+    Parameters
+    ----------
+    original : Path
+        Path to the original image.
+    cleaned : Path
+        Path to the cleaned image.
+    gif_path : Path
+        Output path for the GIF file.
+    duration : float, optional
+        Duration of each frame in seconds, by default 0.5
+    """
+    orig_img = Image.open(original).convert("RGBA")
+    cleaned_img = Image.open(cleaned).convert("RGBA")
+
+    max_w = max(orig_img.width, cleaned_img.width)
+    max_h = max(orig_img.height, cleaned_img.height)
+
+    def pad(img: Image.Image) -> Image.Image:
+        if img.width == max_w and img.height == max_h:
+            return img
+        canvas = Image.new("RGBA", (max_w, max_h))
+        canvas.paste(img, (0, 0))
+        return canvas
+
+    frames: Iterable[Image.Image] = [pad(orig_img), pad(cleaned_img)]
+    imageio.mimsave(gif_path, frames, format="GIF", duration=duration)

--- a/iopaint/schema.py
+++ b/iopaint/schema.py
@@ -278,6 +278,7 @@ class ApiConfig(BaseModel):
     realesrgan_model: RealESRGANModel
     enable_gfpgan: bool
     gfpgan_device: Device
+    enable_gif: bool
     enable_restoreformer: bool
     restoreformer_device: Device
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 wheel
 twine
 pytest-loguru
+imageio
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ gradio==4.21.0
 typer-config==1.4.0
 
 Pillow==9.5.0 # for AnyText
+imageio

--- a/web_app/src/components/Plugins.tsx
+++ b/web_app/src/components/Plugins.tsx
@@ -25,6 +25,7 @@ export enum PluginName {
   GFPGAN = "GFPGAN",
   RestoreFormer = "RestoreFormer",
   InteractiveSeg = "InteractiveSeg",
+  GIF = "GIF",
 }
 
 // TODO: get plugin config from server and using form-render??
@@ -52,6 +53,10 @@ const pluginMap = {
   [PluginName.InteractiveSeg]: {
     IconClass: MousePointerClick,
     showName: "Interactive Segmentation",
+  },
+  [PluginName.GIF]: {
+    IconClass: Blocks,
+    showName: "Make GIF",
   },
 }
 

--- a/web_app/src/lib/types.ts
+++ b/web_app/src/lib/types.ts
@@ -64,6 +64,7 @@ export enum PluginName {
   GFPGAN = "GFPGAN",
   RestoreFormer = "RestoreFormer",
   InteractiveSeg = "InteractiveSeg",
+  GIF = "GIF",
 }
 
 export interface PluginParams {


### PR DESCRIPTION
## Summary
- implement `make_gif` utility
- create CLI flag `--enable-gif`
- generate GIF automatically when saving images
- expose GIF option in web UI plugins
- add `imageio` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_685363f62dbc8328b69bb2bf20227720